### PR TITLE
Add Brainy Note Flutter scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub/
+build/
+# VS Code configuration
+.vscode/
+# IntelliJ
+.idea/
+# Generated files
+**/*.lock
+# Other
+.env

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-AI Note is an intelligent, AI-powered mobile note-taking application specifically designed for high school and university students. Built using Flutter, AI Note offers powerful note management combined with advanced AI capabilities, ensuring efficient and productive study sessions.
+Brainy Note is an intelligent, AI-powered mobile note-taking application specifically designed for high school and university students. Built using Flutter, Brainy Note offers powerful note management combined with advanced AI capabilities, ensuring efficient and productive study sessions.
 
 ## Key Features
 
@@ -30,6 +30,7 @@ AI Note is an intelligent, AI-powered mobile note-taking application specificall
 ### Security and Privacy
 
 * Basic encryption and security measures to ensure user data confidentiality.
+* Notes are encrypted using a simple XOR-based method before storage.
 
 ## Project Structure
 
@@ -78,13 +79,13 @@ The application architecture is structured for easy integration of future enhanc
 1. Clone the repository:
 
    ```
-   git clone https://github.com/yourusername/ai_note.git
+   git clone https://github.com/yourusername/brainy_note.git
    ```
 
 2. Navigate to the project directory:
 
    ```
-   cd ai_note
+   cd brainy_note
    ```
 
 3. Install dependencies:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+linter:
+  rules:
+    avoid_print: false

--- a/lib/features/notes/providers/notes_provider.dart
+++ b/lib/features/notes/providers/notes_provider.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+import '../../../models/note.dart';
+import '../../../services/storage_service.dart';
+import '../../../services/ai_api_service.dart';
+
+/// Provider for managing notes state.
+class NotesProvider extends ChangeNotifier {
+  final StorageService _storage = StorageService.instance;
+  final AiApiService _aiApiService;
+
+  NotesProvider(this._aiApiService);
+
+  List<Note> _notes = [];
+  List<Note> get notes => _notes;
+
+  Future<void> loadNotes() async {
+    _notes = await _storage.fetchNotes();
+    notifyListeners();
+  }
+
+  Future<void> addNote(Note note) async {
+    await _storage.insertNote(note);
+    await loadNotes();
+  }
+
+  Future<void> updateNote(Note note) async {
+    if (note.id != null) {
+      await _storage.updateNote(note);
+      await loadNotes();
+    }
+  }
+
+  Future<void> deleteNote(Note note) async {
+    if (note.id != null) {
+      await _storage.deleteNote(note.id!);
+      await loadNotes();
+    }
+  }
+
+  Future<String> summarize(Note note) async {
+    return _aiApiService.summarize(note.content);
+  }
+
+  Future<String> keywords(Note note) async {
+    return _aiApiService.extractKeywords(note.content);
+  }
+
+  Future<String> generateQuestions(Note note) async {
+    return _aiApiService.generateQuestions(note.content);
+  }
+}

--- a/lib/features/notes/screens/note_detail_screen.dart
+++ b/lib/features/notes/screens/note_detail_screen.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_quill/flutter_quill.dart' as quill;
+import '../providers/notes_provider.dart';
+import '../../../models/note.dart';
+import '../widgets/note_editor.dart';
+
+class NoteDetailScreen extends StatefulWidget {
+  final Note? note;
+  const NoteDetailScreen({super.key, this.note});
+
+  @override
+  State<NoteDetailScreen> createState() => _NoteDetailScreenState();
+}
+
+class _NoteDetailScreenState extends State<NoteDetailScreen> {
+  late TextEditingController _titleController;
+  late quill.QuillController _controller;
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController(text: widget.note?.title ?? '');
+    _controller = widget.note == null
+        ? quill.QuillController.basic()
+        : quill.QuillController(
+            document: quill.Document()..insert(0, widget.note!.content),
+            selection: const TextSelection.collapsed(offset: 0),
+          );
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    final content = _controller.document.toPlainText();
+    final note = Note(
+      id: widget.note?.id,
+      title: _titleController.text,
+      content: content,
+      createdAt: widget.note?.createdAt,
+    );
+    final provider = context.read<NotesProvider>();
+    if (widget.note == null) {
+      await provider.addNote(note);
+    } else {
+      await provider.updateNote(note);
+    }
+    if (mounted) Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.note == null ? 'New Note' : 'Edit Note'),
+        actions: [
+          if (widget.note != null)
+            IconButton(
+              icon: const Icon(Icons.delete),
+              onPressed: () async {
+                await context.read<NotesProvider>().deleteNote(widget.note!);
+                if (mounted) Navigator.pop(context);
+              },
+            ),
+          IconButton(
+            icon: const Icon(Icons.save),
+            onPressed: _save,
+          )
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(hintText: 'Title'),
+            ),
+            const SizedBox(height: 8),
+            Expanded(child: NoteEditor(controller: _controller)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/notes/screens/notes_list_screen.dart
+++ b/lib/features/notes/screens/notes_list_screen.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/notes_provider.dart';
+import 'note_detail_screen.dart';
+
+class NotesListScreen extends StatefulWidget {
+  const NotesListScreen({super.key});
+
+  @override
+  State<NotesListScreen> createState() => _NotesListScreenState();
+}
+
+class _NotesListScreenState extends State<NotesListScreen> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<NotesProvider>().loadNotes();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final notes = context.watch<NotesProvider>().notes;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Brainy Note')),
+      body: ListView.builder(
+        itemCount: notes.length,
+        itemBuilder: (context, index) {
+          final note = notes[index];
+          return ListTile(
+            title: Text(note.title),
+            subtitle: Text(
+              note.content,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => NoteDetailScreen(note: note),
+              ),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => Navigator.push(
+          context,
+          MaterialPageRoute(builder: (_) => const NoteDetailScreen()),
+        ),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/features/notes/widgets/note_editor.dart
+++ b/lib/features/notes/widgets/note_editor.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart' as quill;
+
+/// Rich text editor widget using flutter_quill.
+class NoteEditor extends StatefulWidget {
+  final quill.QuillController controller;
+  const NoteEditor({super.key, required this.controller});
+
+  @override
+  State<NoteEditor> createState() => _NoteEditorState();
+}
+
+class _NoteEditorState extends State<NoteEditor> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        quill.QuillToolbar.basic(controller: widget.controller),
+        Expanded(
+          child: Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              border: Border.all(color: Colors.grey.shade300),
+            ),
+            child: quill.QuillEditor.basic(
+              controller: widget.controller,
+              readOnly: false,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'features/notes/providers/notes_provider.dart';
+import 'services/ai_api_service.dart';
+import 'features/notes/screens/notes_list_screen.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const BrainyNoteApp());
+}
+
+class BrainyNoteApp extends StatelessWidget {
+  const BrainyNoteApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => NotesProvider(
+            AiApiService(apiKey: 'YOUR_OPENAI_API_KEY'),
+          ),
+        ),
+      ],
+      child: MaterialApp(
+        title: 'Brainy Note',
+        theme: ThemeData(primarySwatch: Colors.indigo),
+        home: const NotesListScreen(),
+      ),
+    );
+  }
+}

--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/foundation.dart';
+
+/// Data model for a note.
+class Note {
+  final int? id;
+  final String title;
+  final String content;
+  final DateTime createdAt;
+
+  Note({
+    this.id,
+    required this.title,
+    required this.content,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  /// Convert a note to a map for database storage.
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'title': title,
+      'content': content,
+      'created_at': createdAt.toIso8601String(),
+    };
+  }
+
+  /// Create a [Note] object from a map.
+  factory Note.fromMap(Map<String, dynamic> map) {
+    return Note(
+      id: map['id'] as int?,
+      title: map['title'] as String? ?? '',
+      content: map['content'] as String? ?? '',
+      createdAt: DateTime.parse(map['created_at'] as String),
+    );
+  }
+}

--- a/lib/services/ai_api_service.dart
+++ b/lib/services/ai_api_service.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+/// Service for communicating with external AI APIs.
+class AiApiService {
+  final String apiKey;
+  final http.Client _client;
+
+  AiApiService({required this.apiKey, http.Client? client})
+      : _client = client ?? http.Client();
+
+  static const _baseUrl = 'https://api.openai.com/v1/chat/completions';
+
+  Future<String> summarize(String text) async {
+    final body = jsonEncode({
+      'model': 'gpt-3.5-turbo',
+      'messages': [
+        {'role': 'system', 'content': 'Summarize the following text'},
+        {'role': 'user', 'content': text}
+      ],
+      'max_tokens': 100,
+    });
+    final resp = await _post(body);
+    return resp;
+  }
+
+  Future<String> extractKeywords(String text) async {
+    final body = jsonEncode({
+      'model': 'gpt-3.5-turbo',
+      'messages': [
+        {
+          'role': 'system',
+          'content':
+              'Extract the main keywords from the following text as a comma separated list'
+        },
+        {'role': 'user', 'content': text}
+      ],
+      'max_tokens': 60,
+    });
+    final resp = await _post(body);
+    return resp;
+  }
+
+  Future<String> generateQuestions(String text) async {
+    final body = jsonEncode({
+      'model': 'gpt-3.5-turbo',
+      'messages': [
+        {
+          'role': 'system',
+          'content': 'Generate quiz questions from the following text'
+        },
+        {'role': 'user', 'content': text}
+      ],
+      'max_tokens': 150,
+    });
+    final resp = await _post(body);
+    return resp;
+  }
+
+  Future<String> _post(String body) async {
+    final response = await _client.post(
+      Uri.parse(_baseUrl),
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $apiKey',
+      },
+      body: body,
+    );
+
+    if (response.statusCode == 200) {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final choices = data['choices'] as List<dynamic>;
+      final content = choices.first['message']['content'] as String;
+      return content.trim();
+    } else {
+      throw Exception('Failed to fetch data: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+import '../models/note.dart';
+import '../utils/encryption.dart';
+
+/// Service responsible for local data storage.
+class StorageService {
+  static const _dbName = 'notes.db';
+  static const _dbVersion = 1;
+  static const _tableName = 'notes';
+
+  static final StorageService instance = StorageService._internal();
+  Database? _database;
+
+  StorageService._internal();
+
+  Future<Database> get database async {
+    if (_database != null) return _database!;
+    _database = await _initDatabase();
+    return _database!;
+  }
+
+  Future<Database> _initDatabase() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final path = join(dir.path, _dbName);
+    return openDatabase(
+      path,
+      version: _dbVersion,
+      onCreate: (db, version) async {
+        await db.execute('''
+          CREATE TABLE $_tableName(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT,
+            content TEXT,
+            created_at TEXT
+          )
+        ''');
+      },
+    );
+  }
+
+  Future<int> insertNote(Note note) async {
+    final db = await database;
+    // Encrypt content before saving.
+    final encrypted = Encryption.encrypt(note.content);
+    return db.insert(_tableName, note.copyWith(content: encrypted).toMap());
+  }
+
+  Future<int> updateNote(Note note) async {
+    final db = await database;
+    final encrypted = Encryption.encrypt(note.content);
+    return db.update(
+      _tableName,
+      note.copyWith(content: encrypted).toMap(),
+      where: 'id = ?',
+      whereArgs: [note.id],
+    );
+  }
+
+  Future<int> deleteNote(int id) async {
+    final db = await database;
+    return db.delete(_tableName, where: 'id = ?', whereArgs: [id]);
+  }
+
+  Future<List<Note>> fetchNotes() async {
+    final db = await database;
+    final maps = await db.query(_tableName, orderBy: 'created_at DESC');
+    return [
+      for (final m in maps)
+        Note.fromMap(m).copyWith(
+          content: Encryption.decrypt(m['content'] as String),
+        )
+    ];
+  }
+}
+
+extension on Note {
+  Note copyWith({int? id, String? title, String? content, DateTime? createdAt}) {
+    return Note(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      content: content ?? this.content,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/utils/encryption.dart
+++ b/lib/utils/encryption.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+
+/// Simple XOR-based encryption for demonstration purposes.
+class Encryption {
+  static const _key = 0x42; // Example key. Replace with a secure key in prod.
+
+  static String encrypt(String input) {
+    final bytes = utf8.encode(input);
+    final encrypted = bytes.map((b) => b ^ _key).toList();
+    return base64Encode(encrypted);
+  }
+
+  static String decrypt(String encoded) {
+    final bytes = base64Decode(encoded);
+    final decrypted = bytes.map((b) => b ^ _key).toList();
+    return utf8.decode(decrypted);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,29 @@
+name: brainy_note
+description: Intelligent note-taking app for students
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.1.1
+  sqflite: ^2.3.3
+  path_provider: ^2.1.2
+  path: ^1.8.3
+  http: ^1.1.2
+  crypto: ^3.0.3
+  flutter_quill: ^9.3.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  mockito: ^5.4.4
+  test: ^1.24.6
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/

--- a/test/note_model_test.dart
+++ b/test/note_model_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import '../lib/models/note.dart';
+
+void main() {
+  test('Note toMap and fromMap', () {
+    final note = Note(title: 't', content: 'c');
+    final map = note.toMap();
+    final restored = Note.fromMap(map);
+    expect(restored.title, note.title);
+    expect(restored.content, note.content);
+  });
+}


### PR DESCRIPTION
## Summary
- initialize Flutter project skeleton for **Brainy Note**
- add note model and XOR-based encryption utilities
- implement local storage service with Sqflite
- create AI API service with placeholder OpenAI calls
- provide provider-based state management and basic UI screens
- update README with project description and structure
- include sample unit test and licensing

## Testing
- `flutter test` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854a0cdf0e0832db813c6aaee72216d